### PR TITLE
Start playing the video as soon as it is ready

### DIFF
--- a/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
@@ -112,6 +112,7 @@ public class SignVideoFragment extends Fragment implements NetworkManager.Networ
             public void onPrepared(MediaPlayer mp) {
                 mVideo.setMediaController(mMediaController);
                 mMediaController.setAnchorView(mAnchorView);
+                mVideo.start();
             }
         });
 


### PR DESCRIPTION
This should help to fix a UX issue where the video controls are hidden by default, so unless a user knows to tap on the video then tap the play icon, the video appears to not play.

To avoid this, we can just start playing the video once it's ready.

[nzsl-android-autoplay.webm](https://github.com/ODNZSL/nzsl-dictionary-android/assets/292020/b6597cd0-c3fe-4ed2-9954-c2b4c1d0ee86)

Ideally we'd also find a way to just show the controls all the time. I had a quick go at passing a timeout of `0` to [MediaController#show](https://developer.android.com/reference/android/widget/MediaController#show()), but it didn't seem to work.