### PR TITLE
fix: ensure that video controls are shown by default and forever (until dismissed)

### DIFF
--- a/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
@@ -58,7 +58,17 @@ public class SignVideoFragment extends Fragment implements NetworkManager.Networ
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mMediaController = new MediaController(getContext());
+        mMediaController = new MediaController(getContext()) {
+            @Override
+            public void show(int timeout) {
+                // we want the controller to remain shown until hide() is called by default,
+                // which can be done by passing a timeout of 0; however some of the private
+                // internals of MediaController call show _and_ they favor doing so with the
+                // default value explicitly rather than calling show(), so we have to do this
+                // override which just turns any use of the default value into 0.
+                super.show(timeout == 3000 ? 0 : timeout);
+            }
+        };
         mNetworkManager = new NetworkManager();
         if (getArguments() != null) {
             mDictItem = (DictItem) getArguments().getSerializable(ARG_DICT_ITEM);

--- a/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/SignVideoFragment.java
@@ -108,10 +108,22 @@ public class SignVideoFragment extends Fragment implements NetworkManager.Networ
                 return false;
             }
         });
+
+        final boolean[] isPrepared = { false };
         mVideo.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
             public void onPrepared(MediaPlayer mp) {
+                // avoid resetting the media controller multiple times, because
+                // that triggers the controls to be hidden which can be confusing
+                if (isPrepared[0]) {
+                    mVideo.start();
+
+                    return;
+                }
+
                 mVideo.setMediaController(mMediaController);
                 mMediaController.setAnchorView(mAnchorView);
+                isPrepared[0] = true;
+
                 mVideo.start();
             }
         });


### PR DESCRIPTION
This is a combo of two things:
  1. `onPrepared` is called for the video fragment in the `ViewPager` when the component is first created (even though its not visible UI-wise), _and_ then it is called when you actually switch to that tab
  2. `setMediaController` calls `hide()` whenever you provide a non-null `MediaController`

I don't think there's much more to say that isn't either explained in my code comments or implicitly understood as "because android" - namely, I couldn't find a way to avoid using a `final boolean[]` because `setMediaController` comes from the `ViewPager` component (which I think is more work to extend and override? but could be wrong), I couldn't find anyway to check what the current `MediaController` is (i.e. so we can't do `if (getMediaController() != current) { setMediaController(...) }`), and while arguably it would be better to reuse the fragment my Android is too rusty to take that on right now.

A bonus improvement from this is that the duration looks better: currently because the video player shows before the video is loaded (which is what I assume triggers `onPrepared`), our efforts to show the controls result in them showing with a duration of "00:00" before being hidden when `onPrepared` is called (due to `setMediaController`), and then our new efforts to re-show the controls results in the correct duration being shown - part of this change means the controls just always show, so most of the time you don't notice the "00:00" because of how fast the video loads in.

(sorry @joshmcarthur I don't have fancy recording software to be able to do a video 😅)

----

Resolves #75 