### PR TITLE
fix: throw if column is not found (which should never happen)

### DIFF
--- a/app/src/main/java/com/hewgill/android/nzsldict/FavouritesActivity.java
+++ b/app/src/main/java/com/hewgill/android/nzsldict/FavouritesActivity.java
@@ -217,7 +217,7 @@ public class FavouritesActivity extends BaseActivity implements DictionaryAdapte
 
                         @Override
                         public void run() {
-                            int status = result.getInt(result.getColumnIndex(DownloadManager.COLUMN_STATUS));
+                            int status = result.getInt(result.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS));
                             isDownloading = FavouritesActivity.this.notifyDownloadProgress(item, status);
                         }
                     });


### PR DESCRIPTION
`#getInt` expects a value of 0 or higher, but `getColumnIndex` returns a value of -1 or higher - switching to `#getColumnIndexOrThrow` resolves this, and should be fine as we always expect the column to exist.

This is required for #78