### PR TITLE
chore: ignore `MissingPrefix` lint for `fontPath` attributes

### DIFF
--- a/app/src/main/res/layout/title_bar.xml
+++ b/app/src/main/res/layout/title_bar.xml
@@ -7,6 +7,9 @@
   >
 
     <TextView
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:ignore="MissingPrefix"
+
         style="@style/TextAppearance.Widget.AppCompat.Toolbar.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -17,6 +20,9 @@
         />
 
     <TextView
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:ignore="MissingPrefix"
+
         style="@style/TextAppearance.Widget.AppCompat.Toolbar.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
I think [this is the proper way to do fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml), but I don't want to rock the boat too much so for now let's just ignore these so we can get #78 passing