### PR TITLE
Upgrade Gradle and Android Build Tools to support Android SDK 34 Compilation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'com.android.application'
 android {
     namespace 'com.hewgill.android.nzsldict'
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.hewgill.android.nzsldict"
         minSdkVersion 14
-        targetSdkVersion 33
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         versionCode 47
         versionName "47"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.hewgill.android.nzsldict'
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.hewgill.android.nzsldict"
     android:installLocation="preferExternal">
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request ultimately updates Android SDK to 34, which is required by November 1. To accomplish this, updates were also necessary to Gradle and Android Build Tools, which were sufficiently old to cause compilation errors with the new SDK version.

This requires some minor changes to the code, specifically moving the namespace from AndroidManifest.xml to the app's build.gradle. This version also updates the required Java version to from 7 to 8.